### PR TITLE
Add hint to username field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ out
 lint.xml
 .idea/*
 .DS_Store
+*.log

--- a/res/layout/table_layout_10.xml
+++ b/res/layout/table_layout_10.xml
@@ -4,9 +4,9 @@
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-  
+
           http://www.apache.org/licenses/LICENSE-2.0
-  
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
    <TableRow>
        <TextView android:text="@string/table_layout_10_user" android:textStyle="bold" android:gravity="right" android:padding="3dip" android:contentDescription="@string/table_layout_10_user"/>
 
-       <EditText android:id="@+id/username" android:text="@string/table_layout_10_username_text" android:padding="3dip" android:scrollHorizontally="true" android:contentDescription="@string/table_layout_10_username_text"/>
+       <EditText android:id="@+id/username" android:text="@string/table_layout_10_username_text" android:padding="3dip" android:scrollHorizontally="true" android:contentDescription="@string/table_layout_10_username_text" android:inputType="textNoSuggestions" android:hint="enter username"/>
    </TableRow>
 
    <TableRow>


### PR DESCRIPTION
Add a hint to the `view.TableLayout10` activity. This will allow the Android clear specs to be shifted over to that activity, so we can more easily test the clearing of the password field (which is also in that activity).
