### PR TITLE
Add page for interacting with text fields

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2073,6 +2073,14 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".view.TextFields"
+                  android:label="Views/TextFields">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="appium.android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
         <activity android:name=".view.Buttons1"
                 android:label="Views/Buttons">
             <intent-filter>

--- a/res/layout/text_fields.xml
+++ b/res/layout/text_fields.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="match_parent" android:layout_height="match_parent">
+
+    <LinearLayout android:orientation="vertical" android:layout_width="match_parent" android:layout_height="wrap_content">
+
+      <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="wrap_content">
+
+        <EditText android:id="@+id/edit" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textNoSuggestions" android:hint="hint text"/>
+
+      </LinearLayout>
+
+      <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="wrap_content">
+
+        <EditText android:id="@+id/edit1" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textNoSuggestions"/>
+
+      </LinearLayout>
+
+      <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="wrap_content">
+
+        <EditText android:id="@+id/edit2" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textNoSuggestions"/>
+
+      </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/src/io/appium/android/apis/view/TextFields.java
+++ b/src/io/appium/android/apis/view/TextFields.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.android.apis.view;
+
+// Need the following import to get access to the app resources, since this
+// class is in a sub-package.
+import io.appium.android.apis.R;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Spinner;
+
+
+/**
+ * A gallery of basic controls: Button, EditText, RadioButton, Checkbox,
+ * Spinner. This example uses the light theme.
+ */
+public class TextFields extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_fields);
+    }
+}


### PR DESCRIPTION
To this point we've been using the `.view.Controls1` activity to test typing and other details of text fields. There are, however, issues with multiple text fields (see, for instance, appium/appium#4297). Rather than pollute the control activity, this adds `.view.TextFields` which has three `android.widget.EditText` elements, and can be extended if we run into things in the future.