### PR TITLE
Add view to display key events

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2821,6 +2821,13 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".text.KeyEventText" android:label="Text/KeyEventText">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="appium.android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
         <activity android:name=".nfc.ForegroundDispatch" android:label="NFC/ForegroundDispatch">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/res/layout/key_event_text.xml
+++ b/res/layout/key_event_text.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="match_parent" android:layout_height="match_parent">
+
+    <io.appium.android.apis.text.LogTextBox android:id="@+id/text" android:background="@drawable/box" android:layout_width="match_parent" android:layout_height="0dip" android:layout_weight="1" android:scrollbars="vertical" android:contentDescription="" />
+
+    <Button android:id="@+id/clear"  android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="@string/key_event_text_clear_text" android:contentDescription="@string/key_event_text_clear_text"/>
+
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1299,6 +1299,8 @@
     <string name="log_text_box_1_do_nothing_text">Do nothing</string>
     <string name="log_text_box_1_add_text">Add</string>
 
+    <string name="key_event_text_clear_text">Clear</string>
+
     <string name="notify_with_text_long_notify_text">Show Long Notification</string>
     <string name="notify_with_text_short_notify_text">Show Short Notification</string>
 

--- a/src/io/appium/android/apis/text/KeyEventText.java
+++ b/src/io/appium/android/apis/text/KeyEventText.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.android.apis.text;
+
+import io.appium.android.apis.R;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.view.KeyEvent;
+
+/**
+ * Using a LogTextBox to display a scrollable text area
+ * to which text is appended.
+ *
+ */
+public class KeyEventText extends Activity {
+
+    private LogTextBox mText;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.key_event_text);
+
+        mText = (LogTextBox) findViewById(R.id.text);
+
+        Button clearButton = (Button) findViewById(R.id.clear);
+        clearButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                mText.setText("");
+            }
+        });
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        mText.append("[keycode=" + String.valueOf(keyCode) + "] " + event.toString());
+        mText.append("\n\n");
+        return true;
+    }
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        mText.append("[keycode=" + String.valueOf(keyCode) + "] " + event.toString());
+        mText.append("\n\n");
+        return true;
+    }
+}


### PR DESCRIPTION
There is currently no way to reliably test Android key events in Appium. This view just catches `ACTION_UP` and `ACTION_DOWN` events and prints out the data received. 