### PR TITLE
Add view to open Chrome

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1363,6 +1363,12 @@
                 <category android:name="appium.android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity android:name=".view.WebView3" android:label="Views/WebView3">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="appium.android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".view.RelativeLayout1" android:label="Views/Layouts/RelativeLayout/1. Vertical">
             <intent-filter>

--- a/res/layout/webview_3.xml
+++ b/res/layout/webview_3.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2008 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent" android:layout_height="match_parent">
+    <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="vertical">
+        <Button android:id="@+id/wv3" android:text="Open Chrome" android:layout_width="wrap_content" android:layout_height="wrap_content" android:contentDescription="Open Chrome" android:onClick="openUrl"/>
+    </LinearLayout>
+</ScrollView>

--- a/src/io/appium/android/apis/view/WebView3.java
+++ b/src/io/appium/android/apis/view/WebView3.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.android.apis.view;
+
+import android.app.Activity;
+import android.os.Build;
+import android.os.Bundle;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import io.appium.android.apis.R;
+
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.content.ComponentName;
+import android.net.Uri;
+import android.view.View;
+
+/**
+ * Sample: opening Chrome from within an app
+ */
+public class WebView3 extends Activity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.webview_3);
+    }
+
+    public void openUrl(View view) {
+        final String url = "chrome://version/";
+        try {
+            Intent i = new Intent("android.intent.action.MAIN");
+            i.setComponent(ComponentName.unflattenFromString("com.android.chrome/com.android.chrome.Main"));
+            i.addCategory("android.intent.category.LAUNCHER");
+            i.setData(Uri.parse(url));
+            startActivity(i);
+        }
+        catch(ActivityNotFoundException e) {
+            // Chrome is not installed
+            Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            startActivity(i);
+        }
+    }
+}


### PR DESCRIPTION
A view with a button to open Chrome with the url `"chrome://version/"`, under the activity `.view.WebView3`.

Needed to test webview retrieval through app switches.