### PR TITLE
Handle all events so dragging works in Android 7+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2012-2016 Sauce Labs, Inc.
+Copyright 2012-2016 JS Foundation and other contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "android-apidemos",
   "version": "1.1.2",
   "description": "A fork of Google's Android ApiDemos application, used for testing Appium",
+  "license": "Apache-2.0",
   "main": "bin/ApiDemos-debug.apk",
   "directories": {
     "test": "tests"

--- a/res/layout/drag_layout.xml
+++ b/res/layout/drag_layout.xml
@@ -4,9 +4,9 @@
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-  
+
           http://www.apache.org/licenses/LICENSE-2.0
-  
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,8 +26,8 @@
 
     <io.appium.android.apis.view.DraggableDot android:id="@+id/drag_dot_hidden" android:layout_width="wrap_content" android:layout_height="wrap_content" dot:radius="64dp" android:padding="15dp" android:layout_toRightOf="@id/drag_dot_3" android:layout_alignTop="@id/drag_dot_3" android:visibility="invisible" dot:legend="Surprise!"/>
 
-    <TextView android:id="@+id/drag_result_text" android:layout_width="fill_parent" android:layout_height="wrap_content" android:layout_below="@id/drag_explanation" android:layout_alignRight="@id/drag_explanation" android:layout_toRightOf="@id/drag_dot_2"/>
+    <TextView android:id="@+id/drag_result_text" android:layout_width="fill_parent" android:layout_height="fill_parent" android:layout_weight="1" android:layout_below="@id/drag_dot_3" android:layout_alignLeft="@id/drag_dot_3"/>
 
-    <TextView android:id="@+id/drag_text" android:layout_width="fill_parent" android:layout_height="fill_parent" android:layout_weight="1" android:layout_below="@id/drag_dot_3" android:layout_alignLeft="@id/drag_dot_3"/>
+    <TextView android:id="@+id/drag_text" android:layout_width="fill_parent" android:layout_height="fill_parent" android:layout_weight="1" android:layout_below="@id/drag_result_text" android:layout_alignLeft="@id/drag_result_text"/>
 
 </RelativeLayout>

--- a/src/io/appium/android/apis/view/DragAndDropDemo.java
+++ b/src/io/appium/android/apis/view/DragAndDropDemo.java
@@ -47,6 +47,7 @@ public class DragAndDropDemo extends Activity {
         mResultText = (TextView) findViewById(R.id.drag_result_text);
         mResultText.setOnDragListener(new View.OnDragListener() {
             public boolean onDrag(View v, DragEvent event) {
+                mResultText.setText("Dragging...");
                 final int action = event.getAction();
                 switch (action) {
                     case DragEvent.ACTION_DRAG_STARTED: {
@@ -65,7 +66,8 @@ public class DragAndDropDemo extends Activity {
                         mResultText.setText(dropped ? "Dropped!" : "No drop");
                     } break;
                 }
-                return false;
+                // watch all events, or on Android 7+ we don't get the ACTION_DRAG_ENDED event
+                return true;
             }
         });
     }


### PR DESCRIPTION
Return `true` from handler so we get all events. Otherwise we never get the end event on Android 7+. Also changed the placement of the notice, since it was off the screen on some devices.