### PR TITLE
Add length-limited edittext element (id: edit3)

### DIFF
--- a/res/layout/text_fields.xml
+++ b/res/layout/text_fields.xml
@@ -37,6 +37,12 @@
 
       <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="wrap_content">
 
+        <EditText android:id="@+id/edit3" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textNoSuggestions" android:maxLength="11"/>
+
+      </LinearLayout>
+
+      <LinearLayout android:orientation="horizontal" android:layout_width="match_parent" android:layout_height="wrap_content">
+
         <EditText android:id="@+id/edit3" android:layout_width="match_parent" android:layout_height="wrap_content" android:inputType="textNoSuggestions"/>
 
       </LinearLayout>


### PR DESCRIPTION
Add another EditText element that has a max length of 11.

The Android driver tests all either use the first two elements, or get the last one. This means the tests will run against this new version.

Provides the ability to try to test https://github.com/appium/appium/issues/8279