### PR TITLE
ci: Update java to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-      - name: Use Java 11
+      - name: Use Java 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Install dependencies
         run: |
           npm install

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ android-apidemos
 
 A fork of Google's Android ApiDemos application, used for testing Appium
 
-#### Prerequisites
+#### Requirements
 
 - Java 17
+- Node.js (npm)
   
 #### Building
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ android-apidemos
 
 A fork of Google's Android ApiDemos application, used for testing Appium
 
+#### Prerequisites
+
+- Java 17
+  
 #### Building
 
 > npm run build


### PR DESCRIPTION
due to failure when trying to update to the latest gradle version, we need to update Java version to 17 first thing 
* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin 'com.android.internal.application'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /usr/lib/jvm/temurin-11-jdk-amd64
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.