### PR TITLE
Target SDK 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,23 +1,22 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    compileSdk 33
 
     defaultConfig {
         applicationId "io.appium.android.apis"
         minSdkVersion 17
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         versionCode 24
-        versionName '4.1.1'
+        versionName '4.1.5'
 
         testApplicationId "io.appium.android.apis.test"
         testInstrumentationRunner ".app.LocalSampleInstrumentation"
     }
 
     dependencies {
-        implementation 'androidx.appcompat:appcompat:1.4.2'
+        implementation 'androidx.appcompat:appcompat:1.6.1'
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion 33
 
         versionCode 24
-        versionName '4.1.5'
+        versionName '4.2.0'
 
         testApplicationId "io.appium.android.apis.test"
         testInstrumentationRunner ".app.LocalSampleInstrumentation"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- For android.media.audiofx.Visualizer -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -41,6 +42,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
 
     <application
         android:name="ApiDemosApplication"


### PR DESCRIPTION
Removed deprecated `buildToolsVersion`
replaced `compileSdkVersion`  with `compileSdk`
Target SDK 33
Bump `appcompat` from 1.4.2 to 1.6.1
Bump `versionName` to 4.2.0