### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
   },
   "homepage": "https://github.com/appium/android-apidemos",
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "files": [
     "./index.js",
     "./apks"
   ],
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
     "fancy-log": "^2.0.0",
     "@semantic-release/git": "^10.0.1",
     "semantic-release": "^21.0.0",


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10